### PR TITLE
Metricbeat 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 ## Release 0.2.0
 
 **Breaking**
-- Parameter `queue_size` has been removed.
 
 **Added**
 - Parameter `major_version` to configure 6.x versions of vendor repositories
+-- Parameter `queue_size` applies only if `major_version` == '5'
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Parameter `queue_size` has been removed.
 
 **Added**
+- Parameter `major_version` to configure 6.x versions of vendor repositories
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 **Added**
 - Parameter `major_version` to configure 6.x versions of vendor repositories
 -- Parameter `queue_size` applies only if `major_version` == '5'
+Parameter `queue` to configure the internal queue in 6.x versions
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+**Breaking**
+- Parameter `queue_size` has been removed.
+
+**Added**
+
+**Fixes**
+
 ## Release 0.1.0
 
 - Initial release, please review module and [metricbeat](https://www.elastic.co/guide/en/beats/metricbeat/current/index.html) documentation for configuration options.
 
-**Features**
-
-**Bugfixes**
-
-**Known Issues**

--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ class{'metricbeat':
 Please review the [elastic documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/index.html) for configuration options
 and service compatability.
 
+### Upgrade to 6.0
+
+Version 0.2.0 of this module supports Metricbeat 6.0. Please review the [Metricbeat Changelog](https://www.elastic.co/guide/en/beats/libbeat/6.0/release-notes-6.0.0.html)
+for a full list of software changes and the module changelog for a list of module updates.
+
+To upgrade existing installations:
+
+```puppet
+class{'metricbeat':
+  'major_version'  => '6',
+  'package_ensure' => 'latest',
+  ...
+}
+```
+
 ### Processors
 
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Installs and configures metricbeat.
   applicable if `ensure` is 'present'. (default: 'present')
 - `processors`: [Array[Hash]] Add processors to the configuration to run on data
   before sending to the output. (default: undef)
+- `queue_size`: [Integer] The queue size for single events in the processing
+  pipeline. This is only applicable if `major_version` is '5'. (default: 1000)
 - `service_ensure`: [String] Determine the state of the metricbeat service. Must
   be one of 'enabled', 'disabled', 'running', 'unmanaged'. (default: enabled)
 - `service_has_restart`: [Boolean] When true the Service resource issues the

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Installs and configures metricbeat.
   applicable if `ensure` is 'present'. (default: 'present')
 - `processors`: [Array[Hash]] Add processors to the configuration to run on data
   before sending to the output. (default: undef)
+- `queue`: [Hash] Configure the internal queue in packetbeat before being consumed
+  by the output(s) in 6.x versions.
 - `queue_size`: [Integer] The queue size for single events in the processing
   pipeline. This is only applicable if `major_version` is '5'. (default: 1000)
 - `service_ensure`: [String] Determine the state of the metricbeat service. Must

--- a/README.md
+++ b/README.md
@@ -180,8 +180,6 @@ Installs and configures metricbeat.
   applicable if `ensure` is 'present'. (default: 'present')
 - `processors`: [Array[Hash]] Add processors to the configuration to run on data
   before sending to the output. (default: undef)
-- `queue_size`: [Integer] The queue size for single events in the processing
-  pipeline. (default: 1000)
 - `service_ensure`: [String] Determine the state of the metricbeat service. Must
   be one of 'enabled', 'disabled', 'running', 'unmanaged'. (default: enabled)
 - `service_has_restart`: [Boolean] When true the Service resource issues the

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,6 @@ class metricbeat::config inherits metricbeat {
     'fields'            => $metricbeat::fields,
     'fields_under_root' => $metricbeat::fields_under_root,
     'tags'              => $metricbeat::tags,
-    'queue_size'        => $metricbeat::queue_size,
     'logging'           => $metricbeat::logging,
     'processors'        => $metricbeat::processors,
     'metricbeat'        => {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,6 +33,7 @@ class metricbeat::config inherits metricbeat {
       'tags'              => $metricbeat::tags,
       'logging'           => $metricbeat::logging,
       'processors'        => $metricbeat::processors,
+      'queue'             => $metricbeat::queue,
       'metricbeat'        => {
         'modules'           => $metricbeat::modules,
       },

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,18 +9,36 @@ class metricbeat::config inherits metricbeat {
     true    => undef,
     default => '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
   }
-  $metricbeat_config = delete_undef_values({
-    'name'              => $metricbeat::beat_name,
-    'fields'            => $metricbeat::fields,
-    'fields_under_root' => $metricbeat::fields_under_root,
-    'tags'              => $metricbeat::tags,
-    'logging'           => $metricbeat::logging,
-    'processors'        => $metricbeat::processors,
-    'metricbeat'        => {
-      'modules'           => $metricbeat::modules,
-    },
-    'output'            => $metricbeat::outputs,
-  })
+
+  if $metricbeat::major_version == '5' {
+    $metricbeat_config = delete_undef_values({
+      'name'              => $metricbeat::beat_name,
+      'fields'            => $metricbeat::fields,
+      'fields_under_root' => $metricbeat::fields_under_root,
+      'tags'              => $metricbeat::tags,
+      'logging'           => $metricbeat::logging,
+      'processors'        => $metricbeat::processors,
+      'queue_size'        => $metricbeat::queue_size,
+      'metricbeat'        => {
+        'modules'           => $metricbeat::modules,
+      },
+      'output'            => $metricbeat::outputs,
+    })
+  }
+  elsif $metricbeat::major_version == '6' {
+    $metricbeat_config = delete_undef_values({
+      'name'              => $metricbeat::beat_name,
+      'fields'            => $metricbeat::fields,
+      'fields_under_root' => $metricbeat::fields_under_root,
+      'tags'              => $metricbeat::tags,
+      'logging'           => $metricbeat::logging,
+      'processors'        => $metricbeat::processors,
+      'metricbeat'        => {
+        'modules'           => $metricbeat::modules,
+      },
+      'output'            => $metricbeat::outputs,
+    })
+  }
 
   file{'metricbeat.yml':
     ensure       => $metricbeat::ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,10 +71,6 @@
 # processors, provided by libbeat, to process events before they are
 # sent to the output. (default: undef)
 #
-# * `queue_size`
-# [Integer] The size of the internal queue for single events in the
-# processing pipeline. (default: 1000)
-#
 # * `service_ensure`
 # [String] The desirec state of Service['metricbeat']. Only valid when
 # $ensure is present. Valid values are 'enabled', 'disabled', 'running'
@@ -116,7 +112,6 @@ class metricbeat(
   Boolean $manage_repo                                                = true,
   String $package_ensure                                              = 'present',
   Optional[Tuple[Hash]] $processors                                   = undef,
-  Integer $queue_size                                                 = 1000,
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,
   Optional[Array[String]] $tags                                       = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,11 @@
 # processors, provided by libbeat, to process events before they are
 # sent to the output. (default: undef)
 #
+# * `queue`
+# [Hash] Configure the internal queue before being consumed by the output(s)
+# in bulk transactions. As of 6.0 only a memory queue is available, all
+# settings must be configured by example: { 'mem' => {...}}.
+#
 # * `queue_size`
 # [Integer] The size of the internal queue for single events in the
 # processing pipeline. This is only applicable if $major_version is '5'.
@@ -122,6 +127,15 @@ class metricbeat(
   Boolean $manage_repo                                                = true,
   String $package_ensure                                              = 'present',
   Optional[Tuple[Hash]] $processors                                   = undef,
+  Hash $queue                                                         = {
+    'mem' => {
+      'events' => 4096,
+      'flush'  => {
+        'min_events' => 0,
+        'timeout'    => '0s',
+      },
+    },
+  },
   Integer $queue_size                                                 = 1000,
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,11 @@
 # processors, provided by libbeat, to process events before they are
 # sent to the output. (default: undef)
 #
+# * `queue_size`
+# [Integer] The size of the internal queue for single events in the
+# processing pipeline. This is only applicable if $major_version is '5'.
+# (default: 1000)
+#
 # * `service_ensure`
 # [String] The desirec state of Service['metricbeat']. Only valid when
 # $ensure is present. Valid values are 'enabled', 'disabled', 'running'
@@ -117,6 +122,7 @@ class metricbeat(
   Boolean $manage_repo                                                = true,
   String $package_ensure                                              = 'present',
   Optional[Tuple[Hash]] $processors                                   = undef,
+  Integer $queue_size                                                 = 1000,
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,
   Optional[Array[String]] $tags                                       = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,10 @@
 # [Hash] The configuration section of File['metricbeat.yml'] for the
 # logging output. 
 #
+# * `major_version`
+# [Enum] The major version of Metricbeat to install from vendor repositories.
+# Valid values are '5' and '6'. (default: '5')
+#
 # * `manage_repo`
 # [Boolean] Weather the upstream (elastic) repository should be
 # configured. (default: true)
@@ -109,6 +113,7 @@ class metricbeat(
     'to_files'  => true,
     'to_syslog' => false,
   },
+  Enum['5', '6'] $major_version                                       = '5',
   Boolean $manage_repo                                                = true,
   String $package_ensure                                              = 'present',
   Optional[Tuple[Hash]] $processors                                   = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,9 +9,14 @@ class metricbeat::repo inherits metricbeat {
     'Debian': {
       include ::apt
 
+      $download_url = $metricbeat::major_version ? {
+        '5' => 'https://artifacts.elastic.co/packages/5.x/apt',
+        '6' => 'https://artifacts.elastic.co/packages/6.x/apt',
+      }
+
       if !defined(Apt::Source['beats']) {
         apt::source{'beats':
-          location => 'https://artifacts.elastic.co/packages/5.x/apt',
+          location => $download_url,
           release  => 'stable',
           repos    => 'main',
           key      => {
@@ -22,10 +27,16 @@ class metricbeat::repo inherits metricbeat {
       }
     }
     'RedHat': {
+
+      $download_url = $metricbeat::major_version ? {
+        '5' => 'https://artifacts.elastic.co/packages/5.x/yum',
+        '6' => 'https://artifacts.elastic.co/packages/6.x/yum',
+      }
+
       if !defined(Yumrepo['beats']) {
         yumrepo{'beats':
           descr    => 'Elastic repository for 5.x packages',
-          baseurl  => 'https://artifacts.elastic.co/packages/5.x/yum',
+          baseurl  => $download_url,
           gpgcheck => 1,
           gpgkey   => 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
           enabled  => 1,
@@ -33,6 +44,12 @@ class metricbeat::repo inherits metricbeat {
       }
     }
     'SuSe': {
+
+      $download_url = $metricbeat::major_version ? {
+        '5' => 'https://artifacts.elastic.co/packages/5.x/yum',
+        '6' => 'https://artifacts.elastic.co/packages/6.x/yum',
+      }
+
       exec { 'topbeat_suse_import_gpg':
         command => '/usr/bin/rpmkeys --import https://artifacts.elastic.co/GPG-KEY-elasticsearch',
         unless  => '/usr/bin/test $(rpm -qa gpg-pubkey | grep -i "D88E42B4" | wc -l) -eq 1 ',
@@ -40,7 +57,7 @@ class metricbeat::repo inherits metricbeat {
       }
       if !defined (Zypprepo['beats']) {
         zypprepo{'beats':
-          baseurl     => 'https://artifacts.elastic.co/packages/5.x/yum',
+          baseurl     => $download_url,
           enabled     => 1,
           autorefresh => 1,
           name        => 'beats',

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -285,12 +285,6 @@ describe 'metricbeat' do
 
         it { is_expected.to raise_error(Puppet::Error) }
       end
-
-      context 'with queue_size defined' do
-        let(:params) { { 'queue_size' => 1000 } }
-
-        it { is_expected.to raise_error(Puppet::Error) }
-      end
     end
   end
 end

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -241,6 +241,12 @@ describe 'metricbeat' do
 
         it { is_expected.to raise_error(Puppet::Error) }
       end
+
+      context 'with queue_size defined' do
+        let(:params) { { 'queue_size' => 1000 } }
+
+        it { is_expected.to raise_error(Puppet::Error) }
+      end
     end
   end
 end

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -5,10 +5,6 @@ describe 'metricbeat' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      # context 'with defaults' do
-      #  it { is_expected.to raise_error(Puppet::Error) }
-      # end
-
       it { is_expected.to compile }
 
       describe 'metricbeat::config' do
@@ -110,6 +106,54 @@ describe 'metricbeat' do
               type: 'yum',
             )
           end
+        end
+
+        describe 'with major_version = 6' do
+          let(:params) { { 'major_version' => '6' } }
+
+          case os_facts[:osfamily]
+          when 'RedHat'
+            it do
+              is_expected.to contain_yumrepo('beats').with(
+                baseurl: 'https://artifacts.elastic.co/packages/6.x/yum',
+                enabled: 1,
+                gpgcheck: 1,
+                gpgkey: 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
+              )
+            end
+          when 'Debian'
+            it { is_expected.to contain_class('apt') }
+
+            it do
+              is_expected.to contain_apt__source('beats').with(
+                location: 'https://artifacts.elastic.co/packages/6.x/apt',
+                release: 'stable',
+                repos: 'main',
+                key: {
+                  'id' => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+                  'source' => 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
+                },
+              )
+            end
+          when 'SuSe'
+            it do
+              is_expected.to contain_zypprepo('beats').with(
+                baseurl: 'https://artifacts.elastic.co/packages/6.x/yum',
+                autorefresh: 1,
+                enabled: 1,
+                gpgcheck: 1,
+                gpgkey: 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
+                name: 'beats',
+                type: 'yum',
+              )
+            end
+          end
+        end
+
+        describe 'with major_version = idontknow' do
+          let(:params) { { 'major_version' => 'idontknow' } }
+
+          it { is_expected.to raise_error(Puppet::Error) }
         end
       end
 


### PR DESCRIPTION
This PR adds support for Metricbeat 6.x packages and configurations. For a full list of changes see the [Beats Changelog](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-6.0.0.html) and later.

Resolves #2 