### PR TITLE
Changing the data type of the $modules and $processors parameters fro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 Parameter `queue` to configure the internal queue in 6.x versions
 
 **Fixes**
+- Changing the `modules` and `processor` type from `Tuple[hash]` to `Array[Hash]` (#4)
 
 ## Release 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Please review the [documentation](https://www.elastic.co/guide/en/beats/metricbe
 Installs and configures metricbeat.
 
 **Parameters within `metricbeat`**
-- `modules`: [Tuple[Hash]] The required metricbeat.modules section of the configuration.
+- `modules`: [Array[Hash]] The required metricbeat.modules section of the configuration.
 - `outputs`: [Hash] The required output section of the configuration.
 - `beat_name`: [String] The name of the beat shipper (default: hostname)
 - `ensure`: [String] Valid values are 'present' and 'absent'. Determines weather

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@
 # ----------
 #
 # * `modules`
-# Tuple[Hash] The array of modules this instance of metricbeat will
+# Array[Hash] The array of modules this instance of metricbeat will
 # collect. (default: [{}])
 #
 # * `outputs`
@@ -71,7 +71,7 @@
 # $ensure is present. (default: 'present')
 #
 # * `processors`
-# Optional[Tuple[Hash]] An optional list of dictionaries to configure
+# Optional[Array[Hash]] An optional list of dictionaries to configure
 # processors, provided by libbeat, to process events before they are
 # sent to the output. (default: undef)
 #
@@ -100,7 +100,7 @@
 # `tag` field of each published transaction. This is useful for
 # identifying groups of servers by logical property. (default: undef)
 class metricbeat(
-  Tuple[Hash] $modules                                                = [{}],
+  Array[Hash] $modules                                                = [{}],
   Hash $outputs                                                       = {},
   String $beat_name                                                   = $::hostname,
   Boolean $disable_configtest                                         = false,
@@ -126,7 +126,7 @@ class metricbeat(
   Enum['5', '6'] $major_version                                       = '5',
   Boolean $manage_repo                                                = true,
   String $package_ensure                                              = 'present',
-  Optional[Tuple[Hash]] $processors                                   = undef,
+  Optional[Array[Hash]] $processors                                   = undef,
   Hash $queue                                                         = {
     'mem' => {
       'events' => 4096,

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -285,6 +285,37 @@ describe 'metricbeat' do
 
         it { is_expected.to raise_error(Puppet::Error) }
       end
+
+      context 'with multiple modules' do
+        let(:params) do
+          {
+            'ensure'  => 'absent',
+            'modules' => [
+              { 'module' => 'system', 'metricsets' => %w[cpu memory], 'period' => '10s' },
+              { 'module' => 'apache', 'metricsets' => %w[status], 'period' => '10s', 'hosts' => ['http://127.0.0.1'] },
+            ],
+            'outputs' => { 'elasticsearch' => { 'hosts' => ['http://localhost:9200'] } },
+          }
+        end
+
+        it { is_expected.to compile }
+      end
+
+      context 'with multiple processors' do
+        let(:params) do
+          {
+            'ensure'     => 'absent',
+            'modules'    => [{ 'module' => 'system', 'metricsets' => %w[cpu memory], 'period' => '10s' }],
+            'outputs'    => { 'elasticsearch' => { 'hosts' => ['http://localhost:9200'] } },
+            'processors' => [
+              { 'add_cloud_metadata' => { 'timeout' => '3s' } },
+              { 'drop_fields' => { 'fields' => %w[field1 field2] } },
+            ],
+          }
+        end
+
+        it { is_expected.to compile }
+      end
     end
   end
 end


### PR DESCRIPTION
…m Tuple to Array

Resolves #4

As reported a Tuple type only accepts a single argument. This may not be desired in many cases where multiple modules and/or processors are required on a node. An array type accepts a (seemingly) unlimited number of values.

Adding test cases to confirm the issue and the fix.