### PR TITLE
Fix/update configtest cmd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@
 class metricbeat::config inherits metricbeat {
   $validate_cmd      = $metricbeat::disable_configtest ? {
     true    => undef,
-    default => '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
+    default => '/usr/share/metricbeat/bin/metricbeat -test -c %',
   }
 
   if $metricbeat::major_version == '5' {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@
 class metricbeat::config inherits metricbeat {
   $validate_cmd      = $metricbeat::disable_configtest ? {
     true    => undef,
-    default => '/usr/share/metricbeat/bin/metricbeat -test -c %',
+    default => '/usr/share/metricbeat/bin/metricbeat test -c %',
   }
 
   if $metricbeat::major_version == '5' {

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -15,7 +15,7 @@ describe 'metricbeat' do
             group: 'root',
             mode: '0644',
             path: '/etc/metricbeat/metricbeat.yml',
-            validate_cmd: '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
+            validate_cmd: '/usr/share/metricbeat/bin/metricbeat -test -c %',
           )
         end
 
@@ -26,7 +26,7 @@ describe 'metricbeat' do
             is_expected.to contain_file('metricbeat.yml').with(
               ensure: 'absent',
               path: '/etc/metricbeat/metricbeat.yml',
-              validate_cmd: '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
+              validate_cmd: '/usr/share/metricbeat/bin/metricbeat -test -c %',
             )
           end
         end

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -15,7 +15,7 @@ describe 'metricbeat' do
             group: 'root',
             mode: '0644',
             path: '/etc/metricbeat/metricbeat.yml',
-            validate_cmd: '/usr/share/metricbeat/bin/metricbeat -test -c %',
+            validate_cmd: '/usr/share/metricbeat/bin/metricbeat test -c %',
           )
         end
 
@@ -26,7 +26,7 @@ describe 'metricbeat' do
             is_expected.to contain_file('metricbeat.yml').with(
               ensure: 'absent',
               path: '/etc/metricbeat/metricbeat.yml',
-              validate_cmd: '/usr/share/metricbeat/bin/metricbeat -test -c %',
+              validate_cmd: '/usr/share/metricbeat/bin/metricbeat test -c %',
             )
           end
         end


### PR DESCRIPTION
## Motivation

This PR updates the command used to test configurations and resolves issue  #7. The following error occurs when running `6.2.4`

```
Error: Execution of '/usr/share/metricbeat/bin/metricbeat -test -c /etc/metricbeat/metricbeat.yml20180524-5732-1s9xk2k' returned 1: Error: unknown command "/etc/metricbeat/metricbeat.yml20180524-5732-1s9xk2k" for "metricbeat"
Run 'metricbeat --help' for usage.
```