### PR TITLE
manifests: Adding a new parameter config mode to deal with world-readable config files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ class metricbeat::config inherits metricbeat {
     path         => '/etc/metricbeat/metricbeat.yml',
     owner        => 'root',
     group        => 'root',
-    mode         => '0644',
+    mode         => $metricbeat::config_mode,
     content      => inline_template('<%= @metricbeat_config.to_yaml() %>'),
     validate_cmd => $validate_cmd,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,10 @@
 # [String] The name of the beat which is published as the `beat.name`
 # field of each transaction. (default: $::hostname)
 #
+# * `config_mode`
+# [String] The file permission mode of the config file. Must be in Linux
+# octal format. Default: '0600'
+#
 # * `disable_configtest`
 # [Boolean] If true disable configuration file testing. It is generally
 # recommended to leave this parameter at its default value. (default: false)
@@ -103,6 +107,7 @@ class metricbeat(
   Array[Hash] $modules                                                = [{}],
   Hash $outputs                                                       = {},
   String $beat_name                                                   = $::hostname,
+  Pattern[/^0[0-7]{3}$/] $config_mode                                 = '0600',
   Boolean $disable_configtest                                         = false,
   Enum['present', 'absent'] $ensure                                   = 'present',
   Optional[Hash] $fields                                              = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -14,7 +14,7 @@ class metricbeat::repo inherits metricbeat {
         '6' => 'https://artifacts.elastic.co/packages/6.x/apt',
       }
 
-      if !defined(Apt::Source['beats']) {
+      unless defined(Apt::Source['beats']) {
         apt::source{'beats':
           location => $download_url,
           release  => 'stable',
@@ -33,7 +33,7 @@ class metricbeat::repo inherits metricbeat {
         '6' => 'https://artifacts.elastic.co/packages/6.x/yum',
       }
 
-      if !defined(Yumrepo['beats']) {
+      unless defined(Yumrepo['beats']) {
         yumrepo{'beats':
           descr    => 'Elastic repository for 5.x packages',
           baseurl  => $download_url,
@@ -55,7 +55,7 @@ class metricbeat::repo inherits metricbeat {
         unless  => '/usr/bin/test $(rpm -qa gpg-pubkey | grep -i "D88E42B4" | wc -l) -eq 1 ',
         notify  => [ Zypprepo['beats'] ],
       }
-      if !defined (Zypprepo['beats']) {
+      unless defined (Zypprepo['beats']) {
         zypprepo{'beats':
           baseurl     => $download_url,
           enabled     => 1,

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -75,7 +75,7 @@ describe 'metricbeat' do
               ensure: 'present',
               owner: 'root',
               group: 'root',
-              mode: '0644',
+              mode: '0600',
               path: '/etc/metricbeat/metricbeat.yml',
               validate_cmd: '/usr/share/metricbeat/bin/metricbeat test config',
             )

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -13,7 +13,7 @@ describe 'metricbeat' do
             ensure: 'present',
             owner: 'root',
             group: 'root',
-            mode: '0644',
+            mode: '0600',
             path: '/etc/metricbeat/metricbeat.yml',
             validate_cmd: '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
           )
@@ -39,11 +39,32 @@ describe 'metricbeat' do
               ensure: 'present',
               owner: 'root',
               group: 'root',
-              mode: '0644',
+              mode: '0600',
               path: '/etc/metricbeat/metricbeat.yml',
               validate_cmd: nil,
             )
           end
+        end
+
+        describe 'with config_mode = 0644' do
+          let(:params) { { 'config_mode' => '0644' } }
+
+          it do
+            is_expected.to contain_file('metricbeat.yml').with(
+              ensure: 'present',
+              owner: 'root',
+              group: 'root',
+              mode: '0644',
+              path: '/etc/metricbeat/metricbeat.yml',
+              validate_cmd: '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
+            )
+          end
+        end
+
+        describe 'with config_mode = 9999' do
+          let(:params) { { 'config_mode' => '9999' } }
+
+          it { is_expected.to raise_error(Puppet::Error) }
         end
       end
 


### PR DESCRIPTION
Resolves #10 

Some of the metricbeat modules require user credentials to work, it is not ideal to make the file world-readable when you have sensitive information available for non-privileged users. This commit adds a new parameter `config_mode` with default value '0600', making it configurable but setting the default to resolve world-readability.