### PR TITLE
xpack monitoring configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,7 @@ class metricbeat::config inherits metricbeat {
     })
   }
   elsif $metricbeat::major_version == '6' {
-    $metricbeat_config = delete_undef_values({
+    $metricbeat_config_temp = delete_undef_values({
       'name'              => $metricbeat::beat_name,
       'fields'            => $metricbeat::fields,
       'fields_under_root' => $metricbeat::fields_under_root,
@@ -38,8 +38,13 @@ class metricbeat::config inherits metricbeat {
         'modules'           => $metricbeat::modules,
       },
       'output'            => $metricbeat::outputs,
-      'xpack'             => $metricbeat::xpack,
     })
+    if (versioncmp('6.3.0', $metricbeat::package_ensure) >= 0) or ($metricbeat::package_ensure == 'latest') {
+      $metricbeat_config = deep_merge($metricbeat_config_temp, {'xpack' => $metricbeat::xpack})
+    }
+    else {
+      $metricbeat_config = $metricbeat_config_temp
+    }
   }
 
   file{'metricbeat.yml':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class metricbeat::config inherits metricbeat {
         'modules'           => $metricbeat::modules,
       },
       'output'            => $metricbeat::outputs,
+      'xpack'             => $metricbeat::xpack,
     })
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,11 +39,17 @@ class metricbeat::config inherits metricbeat {
       },
       'output'            => $metricbeat::outputs,
     })
-    if (versioncmp('6.3.0', $metricbeat::package_ensure) >= 0) or ($metricbeat::package_ensure == 'latest') {
-      $metricbeat_config = deep_merge($metricbeat_config_temp, {'xpack' => $metricbeat::xpack})
-    }
-    else {
-      $metricbeat_config = $metricbeat_config_temp
+    case $metricbeat::package_ensure {
+      'latest': { $metricbeat_config = deep_merge($metricbeat_config_temp, {'xpack' => $metricbeat::xpack}) }
+      /^\w+$/:  { $metricbeat_config = $metricbeat_config_temp }
+      default:  {
+        if versioncmp($metricbeat::package_ensure, '6.3.0') >= 0 {
+          $metricbeat_config = deep_merge($metricbeat_config_temp, {'xpack' => $metricbeat::xpack})
+        }
+        else {
+          $metricbeat_config = $metricbeat_config_temp
+        }
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,10 @@
 # Optional[Array[String]] An optional list of values to include in the 
 # `tag` field of each published transaction. This is useful for
 # identifying groups of servers by logical property. (default: undef)
+#
+# * `xpack`
+# Optional[Hash] The optional configuration of the 'xpack'
+# section, to send the internal metrics to an Elasticsearch cluster. (default: undef)
 class metricbeat(
   Array[Hash] $modules                                                = [{}],
   Hash $outputs                                                       = {},
@@ -140,6 +144,7 @@ class metricbeat(
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,
   Optional[Array[String]] $tags                                       = undef,
+  Optional[Hash] $xpack                                               = undef,
 ) {
   if $manage_repo {
     class{'metricbeat::repo':}


### PR DESCRIPTION
I'd like to configure the xpack monitoring section of metricbeat.yml, in order to send the internal metrics to an Elasticsearch cluster. Hence I added the corresponding key to the hash $metricbeat_config belonging to the class metricbeat::config