### PR TITLE
xpack monitoring configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ class metricbeat::config inherits metricbeat {
       },
       'output'            => $metricbeat::outputs,
     })
-    
+
     $validate_cmd      = $metricbeat::disable_configtest ? {
       true    => undef,
       default => '/usr/share/metricbeat/bin/metricbeat test config',
@@ -52,7 +52,7 @@ class metricbeat::config inherits metricbeat {
     else {
       $metricbeat_config = $metricbeat_config_temp
     }
-    
+
   }
 
   file{'metricbeat.yml':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,7 @@ class metricbeat::config inherits metricbeat {
     })
   }
   elsif $metricbeat::major_version == '6' {
-    $metricbeat_config = delete_undef_values({
+    $metricbeat_config_temp = delete_undef_values({
       'name'              => $metricbeat::beat_name,
       'fields'            => $metricbeat::fields,
       'fields_under_root' => $metricbeat::fields_under_root,
@@ -39,6 +39,13 @@ class metricbeat::config inherits metricbeat {
       },
       'output'            => $metricbeat::outputs,
     })
+    # Add the 'xpack' section if supported (version >= 6.2.0)
+    if versioncmp($metricbeat::package_ensure, '6.2.0') >= 0 {
+      $metricbeat_config = deep_merge($metricbeat_config_temp, {'xpack' => $metricbeat::xpack})
+    }
+    else {
+      $metricbeat_config = $metricbeat_config_temp
+    }
   }
 
   file{'metricbeat.yml':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,10 @@
 # Optional[Array[String]] An optional list of values to include in the 
 # `tag` field of each published transaction. This is useful for
 # identifying groups of servers by logical property. (default: undef)
+#
+# * `xpack`
+# Optional[Hash] Configuration items to export internal stats to a
+# monitoring Elasticsearch cluster
 class metricbeat(
   Array[Hash] $modules                                                = [{}],
   Hash $outputs                                                       = {},
@@ -140,6 +144,7 @@ class metricbeat(
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,
   Optional[Array[String]] $tags                                       = undef,
+  Optional[Hash] $xpack                                               = undef,
 ) {
   if $manage_repo {
     class{'metricbeat::repo':}


### PR DESCRIPTION
To be able to set xpack opentions (for example to configure [X-Pack Monitoring](https://www.elastic.co/guide/en/beats/metricbeat/current/monitoring.html)) please add an xpack config option.