### PR TITLE
Migrating dependency darin-zypprepo to puppet-zypprepo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
   forge_modules:
     apt: "puppetlabs/apt"
     stdlib: "puppetlabs/stdlib"
-    zypprepo: "darin/zypprepo"
+    zypprepo: "puppet/zypprepo"
   symlinks:
     metricbeat: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": ">= 4.0.0 < 7.0.0"
     },
     {
-      "name": "darin-zypprepo",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "name": "puppet-zypprepo",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The former project is no longer in development. The latter project is more recent and managed by a "trusted" group.