### PR TITLE
Setting the config path in Metricbeat 6.x validate_cmd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,8 @@
 #
 # @summary Manages Metricbeat's configuration file
 class metricbeat::config inherits metricbeat {
+  $dir_name = dirname($metricbeat::config_file)
+
   if $metricbeat::major_version == '5' {
     $metricbeat_config = delete_undef_values({
       'name'              => $metricbeat::beat_name,
@@ -51,7 +53,7 @@ class metricbeat::config inherits metricbeat {
         true    => undef,
         default => $metricbeat::major_version ? {
           '5'     => '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
-          default => '/usr/share/metricbeat/bin/metricbeat test config',
+          default => "/usr/share/metricbeat/bin/metricbeat --path.config ${dir_name} test config",
         }
       }
 
@@ -72,7 +74,7 @@ class metricbeat::config inherits metricbeat {
         true    => undef,
         default => $metricbeat::major_version ? {
           '5' => "\"${metricbeat_path}\" -N configtest -c \"%\"",
-          default => "\"${metricbeat_path}\" test config",
+          default => "\"${metricbeat_path}\" --path.config ${dir_name} test config",
         }
       }
 

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -107,7 +107,7 @@ describe 'metricbeat' do
               is_expected.to contain_file('metricbeat.yml').with(
                 ensure: 'present',
                 path: 'C:/Program Files/Metricbeat/metricbeat.yml',
-                validate_cmd: "\"C:\\Program Files\\Metricbeat\\metricbeat.exe\" test config", # rubocop:disable StringLiterals
+                validate_cmd: "\"C:\\Program Files\\Metricbeat\\metricbeat.exe\" --path.config C:/Program Files/Metricbeat test config", # rubocop:disable StringLiterals
               )
             end
           else
@@ -118,7 +118,7 @@ describe 'metricbeat' do
                 group: 'root',
                 mode: '0600',
                 path: '/etc/metricbeat/metricbeat.yml',
-                validate_cmd: '/usr/share/metricbeat/bin/metricbeat test config',
+                validate_cmd: '/usr/share/metricbeat/bin/metricbeat --path.config /etc/metricbeat test config',
               )
             end
           end


### PR DESCRIPTION
Fixes #24 