### PR TITLE
Bugfix: Run apt-update before package installation

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,6 +29,7 @@ class metricbeat::repo inherits metricbeat {
           },
         }
       }
+      Class['apt::update'] -> Package['metricbeat']
     }
     'RedHat': {
       if !defined(Yumrepo['beats']) {

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -198,6 +198,7 @@ describe 'metricbeat' do
           end
         when 'Debian'
           it { is_expected.to contain_class('apt') }
+          it { is_expected.to contain_class('apt::update').that_comes_before('Package[metricbeat]') }
 
           it do
             is_expected.to contain_apt__source('beats').with(


### PR DESCRIPTION
This commit fixes a bug regarding a missing dependency between `Exec[apt_update]` and `Package[metricbeat]`.

Although the addition of the corresponding apt-repo is always done before the installation of the package, the `apt-update` command fails to do so.

This is a snapshot that confirms the problem. Puppet fails because it is unable to find the `metricbeat` package.
```
Notice: Compiled catalog for b04373fec00a in environment production in 0.43 seconds
Notice: /Stage[main]/Metricbeat::Repo/Apt::Source[beats]/Apt::Key[Add key: 46095ACC8548582C1A2699A9D27D666CD88E42B4 from Apt::Source beats]/Apt_key[Add key: 46095ACC8548582C1A2699A9D27D666CD88E42B4 from Apt::Source beats]/ensure: created
Notice: /Stage[main]/Apt/File[preferences]/ensure: created
Notice: /Stage[main]/Metricbeat::Repo/Apt::Source[beats]/Apt::Setting[list-beats]/File[/etc/apt/sources.list.d/beats.list]/ensure: defined content as '{md5}ddca0756f7c9899c13799b2f55dd0aee'
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/ensure: defined content as '{md5}0962d70c4ec78bbfa6f3544ae0c41974'
Notice: /Stage[main]/Metricbeat::Repo/Apt::Source[beats]/Package[apt-transport-https]/ensure: created
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install metricbeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package metricbeat
Error: /Stage[main]/Metricbeat::Install/Package[metricbeat]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install metricbeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package metricbeat
Notice: /Stage[main]/Metricbeat::Config/File[metricbeat.yml]: Dependency Package[metricbeat] has failures: true
Warning: /Stage[main]/Metricbeat::Config/File[metricbeat.yml]: Skipping because of failed dependencies
Notice: /Stage[main]/Metricbeat::Config/File[/etc/metricbeat/modules.d/system.yml]: Dependency Package[metricbeat] has failures: true
Warning: /Stage[main]/Metricbeat::Config/File[/etc/metricbeat/modules.d/system.yml]: Skipping because of failed dependencies
Notice: /Stage[main]/Metricbeat::Service/Service[metricbeat]: Dependency Package[metricbeat] has failures: true
Warning: /Stage[main]/Metricbeat::Service/Service[metricbeat]: Skipping because of failed dependencies
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
```