### PR TITLE
Separated out the modules.d file management into a new resource type …

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Please review the [documentation](https://www.elastic.co/guide/en/beats/metricbe
     - [Class: metricbeat::install](#class-metricbeatinstall)
     - [Class: metricbeat::repo](#class-metricbeatrepo)
     - [Class: metricbeat::service](#class-metricbeatservice)
+  - [**Custom module templates**](#custom-module-templates)
 
 ### Public Classes
 
@@ -249,6 +250,27 @@ Installs the upstream Yum or Apt repository for the system package manager.
 #### Class: `metricbeat::service`
 
 Manages the metricbeat service.
+
+### Custom module templates
+
+Define a custom configuration file in the modules.d directory using the `metricbeat::modulesd` resource type.
+
+**Parameters within `metricbeat::modulesd`**
+- `template_name`: [String] Filename of the template in modules.d
+- `config`: [Hash] For passing parameters down to the .erb template
+- `source`: Optional[String] Path for the file 'source' parameter, mutually exclusive with `content`
+- `content`: Optional[String] Path for the file 'content' parameter, mutually exclusive with `source`
+
+
+Example usage:
+
+```
+metricbeat::modulesd { 'module_name':
+  config  => $custom_hash,
+  content => template("path/to/your/template.yml.erb"),
+}
+```
+
 
 ## Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,32 +22,34 @@ class metricbeat::config inherits metricbeat {
 
   if $metricbeat::major_version == '5' {
     $metricbeat_config_base = delete_undef_values({
-      'cloud.id'          => $metricbeat::cloud_id,
-      'cloud.auth'        => $metricbeat::cloud_auth,
-      'name'              => $metricbeat::beat_name,
-      'tags'              => $metricbeat::tags,
-      'logging'           => $metricbeat::logging,
-      'processors'        => $metricbeat::processors,
-      'queue_size'        => $metricbeat::queue_size,
-      'metricbeat'        => {
-        'modules'           => $metricbeat::modules,
+      'cloud.id'                       => $metricbeat::cloud_id,
+      'cloud.auth'                     => $metricbeat::cloud_auth,
+      'name'                           => $metricbeat::beat_name,
+      'tags'                           => $metricbeat::tags,
+      'logging'                        => $metricbeat::logging,
+      'processors'                     => $metricbeat::processors,
+      'queue_size'                     => $metricbeat::queue_size,
+      'metricbeat'                     => {
+        'modules' => $metricbeat::modules,
       },
-      'output'            => $metricbeat::outputs,
+      'output'                         => $metricbeat::outputs,
+      'metricbeat.config.modules.path' => '${path.config}/modules.d/*.yml',
     })
 
     $metricbeat_config = deep_merge($metricbeat_config_base, $fields_tmp)
   }
   else {
     $metricbeat_config_base = delete_undef_values({
-      'cloud.id'           => $metricbeat::cloud_id,
-      'cloud.auth'         => $metricbeat::cloud_auth,
-      'name'               => $metricbeat::beat_name,
-      'tags'               => $metricbeat::tags,
-      'logging'            => $metricbeat::logging,
-      'processors'         => $metricbeat::processors,
-      'queue'              => $metricbeat::queue,
-      'metricbeat.modules' => $modules_arr,
-      'output'             => $metricbeat::outputs,
+      'cloud.id'                       => $metricbeat::cloud_id,
+      'cloud.auth'                     => $metricbeat::cloud_auth,
+      'name'                           => $metricbeat::beat_name,
+      'tags'                           => $metricbeat::tags,
+      'logging'                        => $metricbeat::logging,
+      'processors'                     => $metricbeat::processors,
+      'queue'                          => $metricbeat::queue,
+      'metricbeat.modules'             => $modules_arr,
+      'output'                         => $metricbeat::outputs,
+      'metricbeat.config.modules.path' => '${path.config}/modules.d/*.yml',
     })
 
     $metricbeat_config_temp = deep_merge($metricbeat_config_base, $fields_tmp)
@@ -62,17 +64,12 @@ class metricbeat::config inherits metricbeat {
 
   }
 
-  # extra modules under `modules.d` folder, if any
+  # Create modules.d files that exist in hiera then collect any created via exported resources
   $module_templates_real = hiera_array('metricbeat::module_templates', $metricbeat::module_templates)
-  each($module_templates_real) |$module_name| {
-    file { "${metricbeat::config_dir}/modules.d/${module_name}.yml":
-      ensure => present,
-      source => "puppet:///modules/metricbeat/${module_name}.yml",
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
+  $module_templates_real.each |$module| {
+    metricbeat::modulesd { $module: }
   }
+  Metricbeat::Modulesd <<||>>
 
   case $::kernel {
     'Linux': {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -67,7 +67,7 @@ class metricbeat::config inherits metricbeat {
   # Create modules.d files that exist in hiera then collect any created via exported resources
   $module_templates_real = hiera_array('metricbeat::module_templates', $metricbeat::module_templates)
   $module_templates_real.each |$module| {
-    metricbeat::modulesd { $module: }
+    @@metricbeat::modulesd { $module: }
   }
   Metricbeat::Modulesd <<||>>
 

--- a/manifests/modulesd.pp
+++ b/manifests/modulesd.pp
@@ -20,6 +20,6 @@ define metricbeat::modulesd(
     group   => 'root',
     mode    => '0644',
     require => Class['::metricbeat'],
-    notify  => Service['metricbeat'],
+    notify  => Class['::metricbeat::service'],
   }
 }

--- a/manifests/modulesd.pp
+++ b/manifests/modulesd.pp
@@ -1,0 +1,25 @@
+# Enable a modules.d file either via a custom source, custom template or default module template
+# $config can be used to pass down parameters into an .erb template
+define metricbeat::modulesd(
+  String           $template_name = $name,
+  Hash             $config        = {},
+  Optional[String] $source        = undef,
+  Optional[String] $content       = undef,
+){
+  # Use the default template as the source if non specified
+  if ! $source and ! $content {
+    $default_source = "puppet:///modules/metricbeat/${template_name}.yml"
+  } elsif $source {
+    $default_source = $source
+  }
+  file { "${metricbeat::config_dir}/modules.d/${template_name}.yml":
+    ensure  => present,
+    source  => $default_source,
+    content => $content,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => Class['::metricbeat'],
+    notify  => Service['metricbeat'],
+  }
+}


### PR DESCRIPTION
…that allows the defining of modules.d files as erb templates, static content files and preserving the original functionality as well. The new type can also be used as an exported resource which is collected by the metricbeat::config class.

Added a default configuration parameter to allow the use of modules.d files.