### PR TITLE
fixing fields_under_root issue

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,11 +15,7 @@ class metricbeat::config inherits metricbeat {
 
   # if fields are "under root", then remove prefix
   if $metricbeat::fields_under_root == true {
-    if $metricbeat::fields_under_root == true {
       $fields_tmp = $metricbeat::fields.each | $key, $value | { {$key => $value} }
-    } else {
-      $fields_tmp = $metricbeat::fields
-    }
   } else {
       $fields_tmp = $metricbeat::fields
   }


### PR DESCRIPTION
Unnecessary it statements which are preventing to add  'fields' 'and fields_under_root' to metricbeat configuration. This fix actually produced the required metricbeat configuration for fields_under_root and fields.