### PR TITLE
Use lookup to merge metricbeat::modules config from different levels …

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,8 +6,13 @@
 # @summary Manages Metricbeat's configuration file
 class metricbeat::config inherits metricbeat {
 
+  # Use lookup to merge metricbeat::modules config from different levels of hiera
+  $modules_lookup = lookup('metricbeat::modules', undef, 'unique', undef)
+  # Check to see if anything has been confiugred in hiera
+  if $modules_lookup {
+    $modules_arr = $modules_lookup
   # check if array is empty, no need to create a config entry then
-  if $metricbeat::modules[0].length() > 0 {
+  } elsif $metricbeat::modules[0].length() > 0 {
     $modules_arr = $metricbeat::modules
   } else {
     $modules_arr = undef


### PR DESCRIPTION
The lookup will merge hiera configuration such that 

common.yaml
```
metricbeat::modules:
  - module: system
    period: 10s
    metricsets:
      - cpu
      - load
      - memory
```

node.yaml
```
metricbeat::modules:
  - module: nginx
    period: 10s
    hosts: http://127.0.0.1
```

provide the config 
```
metricbeat.modules:
- module: nginx
  period: 10s
  hosts: http://127.0.0.1
- module: system
  period: 10s
  metricsets:
  - cpu
  - load
  - memory
```