### PR TITLE
Bump module and dependencies versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "coreyh-metricbeat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "coreyh",
   "summary": "A module to install, configure and manage the Metricbeat collector.",
   "license": "Apache-2.0",
@@ -10,23 +10,23 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0 < 6.0.0"
+      "version_requirement": ">= 4.13.0 < 7.0.0"
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.5.0 < 4.0.0"
+      "version_requirement": ">= 0.5.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-powershell",
-      "version_requirement": ">= 1.0.1 < 3.0.0"
+      "version_requirement": ">= 1.0.1 < 4.0.0"
     },
     {
       "name": "puppet-zypprepo",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs-pwshlib",


### PR DESCRIPTION
Bumping dependencies to their major releases. All the latest versions
contain all the functions and parameters used in the module.
pdk validate and pdk test unit complete with no errors.

This would allow upgrading modules on servers which are currently locked to old releases due to the inability of upgrading major modules like stdlib and archive