### PR TITLE
fix issue #44

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,12 +75,9 @@ class metricbeat::config inherits metricbeat {
 
   }
 
-  # Create modules.d files that exist in hiera then collect any created via exported resources
+  # Create modules.d files that exist in hiera or passed to metricbeat class as parameter
   $module_templates_real = hiera_array('metricbeat::module_templates', $metricbeat::module_templates)
-  $module_templates_real.each |$module| {
-    @@metricbeat::modulesd { $module: }
-  }
-  Metricbeat::Modulesd <<||>>
+  metricbeat::modulesd { $module_templates_real: }
 
   case $::kernel {
     'Linux': {


### PR DESCRIPTION
Original usage of exported resources leads to duplicate declaration errors.
Actually there's no need in neither exported resources collector no create_resources() because $module_templates_real is an array that can be directly used for resource declaration.