### PR TITLE
Updated dependecy version for puppetlabs-powershell in the metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs-powershell",
-      "version_requirement": ">= 1.0.1 < 4.0.0"
+      "version_requirement": ">= 1.0.1 < 5.0.0"
     },
     {
       "name": "puppet-zypprepo",


### PR DESCRIPTION
I updated the dependency version range in the metadata.json file for the puppetlabs-powershell module to include the latest version. 
This fixes the following error when the command `puppet module list` is run. 
```
Warning: Module 'puppetlabs-powershell' (v4.0.0) fails to meet some dependencies:
  'coreyh-metricbeat' (v0.4.1) requires 'puppetlabs-powershell' (>= 1.0.1 < 4.0.0)```
```