### PR TITLE
Add option to use the archive module to also unzip the package

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,10 @@ Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
+Style/BracesAroundHashParameters:
+  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
+    See https://github.com/rubocop-hq/rubocop/pull/7643
+  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "jpogran.puppet-vscode",
+    "puppet.puppet-vscode",
     "rebornix.Ruby"
   ]
 }

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
     config.add_pr_wo_labels = true
     config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",
@@ -60,11 +60,11 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
       },
       "Added" => {
         "prefix" => "### Added",
-        "labels" => ["feature", "enhancement"],
+        "labels" => ["enhancement", "feature"],
       },
       "Fixed" => {
         "prefix" => "### Fixed",
-        "labels" => ["bugfix"],
+        "labels" => ["bug", "documentation", "bugfix"],
       },
     }
   end
@@ -72,16 +72,15 @@ else
   desc 'Generate a Changelog from GitHub'
   task :changelog do
     raise <<EOM
-The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+The changelog tasks depends on recent features of the github_changelog_generator gem.
 Please manually add it to your .sync.yml for now, and run `pdk update`:
 ---
 Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+        version: '~> 1.15'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
 EOM
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,11 @@
 # from the target node. This is good for bulk uninstallation across a
 # network. Valid values are 'present' or 'absent'. (default: 'present')
 #
+# * `extract_method`
+# [Enum] Select which extraction method to use for the downloaded zip file.
+# Only valid on Windows nodes.
+# Valid values are `shell` or `archive`
+#
 # * `fields`
 # Optional[Hash] Optional fields to add to each transaction to provide
 # additonal information. (default: undef)
@@ -169,6 +174,7 @@ class metricbeat(
   Boolean $disable_configtest                                         = $metricbeat::params::disable_configtest,
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $download_url  = $metricbeat::params::download_url,
   Enum['present', 'absent'] $ensure                                   = $metricbeat::params::ensure,
+  Enum['shell', 'archive'] $extract_method                            = $metricbeat::params::extract_method,
   Optional[Hash] $fields                                              = $metricbeat::params::fields,
   Boolean $fields_under_root                                          = $metricbeat::params::fields_under_root,
   Optional[String] $install_dir                                       = $metricbeat::params::install_dir,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,34 +22,48 @@ class metricbeat::install inherits metricbeat {
       }
     }
 
-    archive{ $zip_file:
-      source       => $metricbeat::real_download_url,
-      cleanup      => false,
-      creates      => $version_file,
-      proxy_server => $metricbeat::proxy_address,
-    }
-    exec{"unzip ${filename}":
-      command => "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path '${metricbeat::install_dir}')).Copyhere(\$sh.namespace((Convert-Path '${zip_file}')).items(), 16)", # lint:ignore:140chars
-      creates => $version_file,
-      require => [
-        File[$metricbeat::install_dir],
-        Archive[$zip_file],
-      ],
+    if $metricbeat::extract_method == 'shell' {
+      archive { $zip_file:
+        source       => $metricbeat::real_download_url,
+        cleanup      => false,
+        creates      => $version_file,
+        proxy_server => $metricbeat::proxy_address,
+      }
+
+      exec{"unzip ${filename}":
+        command => "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path '${metricbeat::install_dir}')).Copyhere(\$sh.namespace((Convert-Path '${zip_file}')).items(), 16)", # lint:ignore:140chars
+        creates => $version_file,
+        require => [
+          File[$metricbeat::install_dir],
+          Archive[$zip_file],
+        ],
+      }
+      # Clean up after ourselves
+      file{$zip_file:
+        ensure  => absent,
+        backup  => false,
+        require => Exec["unzip ${filename}"],
+        before  => Exec["stop service ${filename}"],
+      }
+
+    } else {
+      archive { $zip_file:
+        source       => $metricbeat::real_download_url,
+        cleanup      => true,
+        extract      => true,
+        extract_path => $metricbeat::install_dir,
+        creates      => $version_file,
+        proxy_server => $metricbeat::proxy_address,
+        before       => Exec["stop service ${filename}"],
+      }
     }
 
-    # Clean up after ourselves
-    file{$zip_file:
-      ensure  => absent,
-      backup  => false,
-      require => Exec["unzip ${filename}"],
-    }
 
     # You can't remove the old dir while the service has files locked...
     exec{"stop service ${filename}":
       command => 'Set-Service -Name metricbeat -Status Stopped',
       creates => $version_file,
       onlyif  => 'if(Get-WmiObject -Class Win32_Service -Filter "Name=\'metricbeat\'") {exit 0} else {exit 1}',
-      require => Exec["unzip ${filename}"],
     }
     exec{"rename ${filename}":
       command => "Remove-Item '${install_folder}' -Recurse -Force -ErrorAction SilentlyContinue;Rename-Item '${metricbeat::install_dir}/${filename}' '${install_folder}'", # lint:ignore:140chars

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class metricbeat::params {
   $config_mode        = '0600'
   $disable_configtest = false
   $download_url       = undef
+  $extract_method     = 'shell'
   $fields             = undef
   $fields_under_root  = false
   $manage_repo        = true

--- a/metadata.json
+++ b/metadata.json
@@ -102,7 +102,7 @@
     "logstash",
     "elastic"
   ],
-  "pdk-version": "1.17.0",
-  "template-url": "pdk-default#1.17.0",
-  "template-ref": "tags/1.17.0-0-gd3a4319"
+  "pdk-version": "1.18.1",
+  "template-url": "pdk-default#1.18.1",
+  "template-ref": "tags/1.18.1-0-g3d2e75c"
 }

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'metricbeat' do
-  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
@@ -127,15 +127,21 @@ describe 'metricbeat' do
 
       describe 'metricbeat::install' do
         if os_facts[:kernel] == 'windows'
+          context 'with shell extractor' do
+            let(:params) { { 'extract_method' => 'shell' } }
+
+            it {
+              is_expected.to contain_exec('unzip metricbeat-6.6.1-windows-x86_64').with(
+                command: "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path 'C:/Program Files')).Copyhere(\$sh.namespace((Convert-Path 'C:/Windows/Temp/metricbeat-6.6.1-windows-x86_64.zip')).items(), 16)", # rubocop:disable LineLength
+                creates: 'C:/Program Files/Metricbeat/metricbeat-6.6.1-windows-x86_64',
+              )
+            }
+          end
           it do
             is_expected.to contain_file('C:/Program Files').with(ensure: 'directory')
             is_expected.to contain_archive('C:/Windows/Temp/metricbeat-6.6.1-windows-x86_64.zip').with(
               creates: 'C:/Program Files/Metricbeat/metricbeat-6.6.1-windows-x86_64',
               source: 'https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-6.6.1-windows-x86_64.zip',
-            )
-            is_expected.to contain_exec('unzip metricbeat-6.6.1-windows-x86_64').with(
-              command: "\$sh=New-Object -COM Shell.Application;\$sh.namespace((Convert-Path 'C:/Program Files')).Copyhere(\$sh.namespace((Convert-Path 'C:/Windows/Temp/metricbeat-6.6.1-windows-x86_64.zip')).items(), 16)", # rubocop:disable LineLength
-              creates: 'C:/Program Files/Metricbeat/metricbeat-6.6.1-windows-x86_64',
             )
             is_expected.to contain_exec('stop service metricbeat-6.6.1-windows-x86_64').with(
               creates: 'C:/Program Files/Metricbeat/metricbeat-6.6.1-windows-x86_64',

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'metricbeat::params' do
-  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |c|
     # set to strictest setting for testing
     # by default Puppet runs at warning level
     Puppet.settings[:strict] = :warning
+    Puppet.settings[:strict_variables] = true
   end
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do


### PR DESCRIPTION
I've found that the CopyHere method can sometimes silently fail to extract the zip file on Windows.  It fails consistently when Puppet runs as a domain user instead of LocalSystem.

Adding a parameter `extract_method` to the module to control whether to use the `archive` module or the current behaviour.  Defaults to the current behaviour.  Tests are updated but I didn't add context for the new parameter (since it just means there is no `exec` anymore) - I guess we could test that the correct parameters are being passed though.

Also took the opportunity to fix up the failing Ubuntu tests and update to version 1.18.1 of PDK.

All tests pass using the provided gitlab-ci.yml and using `pdk test unit` and I've performed manual acceptance tests on a Windows Server 2019 box