### PR TITLE
Change Exported Resource to Virtual to Avoid Duplication Errors

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,7 +80,7 @@ class metricbeat::config inherits metricbeat {
   # Create modules.d files that exist in hiera then collect any created via exported resources
   $module_templates_real = hiera_array('metricbeat::module_templates', $metricbeat::module_templates)
   $module_templates_real.each |$module| {
-    @@metricbeat::modulesd { $module: }
+    @metricbeat::modulesd { $module: }
   }
   Metricbeat::Modulesd <<||>>
 


### PR DESCRIPTION
This is to fix:

```
2021-04-21T09:43:41.325-04:00 ERROR [qtp3040397-129] [puppetserver] Puppet A duplicate resource was found while collecting exported resources, with the type and title Metricbeat::Modulesd[system] on node XXXX
2021-04-21T09:43:41.327-04:00 ERROR [qtp3040397-129] [puppetserver] Puppet Server Error: A duplicate resource was found while collecting exported resources, with the type and title Metricbeat::Modulesd[system] on node XXXX
```