### PR TITLE
Validation command

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,7 +90,7 @@ class metricbeat::config inherits metricbeat {
         true    => undef,
         default => $metricbeat::major_version ? {
           '5'     => '/usr/share/metricbeat/bin/metricbeat -configtest -c %',
-          default => "/usr/share/metricbeat/bin/metricbeat --path.config ${metricbeat::config_dir} test config",
+          default => "/usr/share/metricbeat/bin/metricbeat test config -c %",
         }
       }
 
@@ -111,7 +111,7 @@ class metricbeat::config inherits metricbeat {
         true    => undef,
         default => $metricbeat::major_version ? {
           '5' => "\"${metricbeat_path}\" -N configtest -c \"%\"",
-          default => "\"${metricbeat_path}\" --path.config \"${metricbeat::config_dir}\" test config",
+          default => "\"${metricbeat_path}\" test config -c \"%\"",
         }
       }
 


### PR DESCRIPTION
- Update default validation command
The current command will validate the /etc/metricbeat directory which defaults to checking metricbeat.yml.
Since Puppet updates a temporary file before validation, there are situations where metricbeat.yml will always be invalid and end up in a fail loop due broken validation command

Fixes #53 