### PR TITLE
Adding a managed type for service_ensure

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Installs and configures metricbeat.
 - `proxy_address`: [HTTP(S) URL] The proxy address used for downloading files. (default: undef)
 - `queue`: [Hash] Configure the internal queue in packetbeat before being consumed by the output(s) in 6.x versions and greater.
 - `queue_size`: [Integer] The queue size for single events in the processing pipeline. This is only applicable if `major_version` is '5'. (default: 1000)
-- `service_ensure`: [String] Determine the state of the metricbeat service. Must be one of 'enabled', 'disabled', 'running', 'unmanaged'. (default: enabled)
+- `service_ensure`: [String] Determine the state of the metricbeat service. Must be one of 'enabled', 'disabled', 'running', 'unmanaged', "managed". (default: enabled)
 - `service_has_restart`: [Boolean] When true the Service resource issues the 'restart' command instead of 'stop' and 'start'. (default: true)
 - `service_provider`: [String] The optional service provider of the node. (default: 'redhat' on RedHat nodes, undef otherwise)
 - `tags`: [Array] Optional list of tags to help group different logical properties easily. (default: undef)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,8 +127,8 @@
 #
 # * `service_ensure`
 # [String] The desirec state of Service['metricbeat']. Only valid when
-# $ensure is present. Valid values are 'enabled', 'disabled', 'running'
-# or 'unmanaged'. (default: 'enabled')
+# $ensure is present. Valid values are 'enabled', 'disabled', 'running',
+# 'unmanaged' or 'managed'. (default: 'enabled')
 #
 # * `service_has_restart`
 # [Boolean] When true use the restart function of the init script.
@@ -166,39 +166,39 @@
 # [Hash] Setup that will be created. Commonly used to create setup using hiera
 #
 class metricbeat(
-  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $apt_repo_url  = $metricbeat::params::apt_repo_url,
-  Optional[String] $cloud_id                                          = $metricbeat::params::cloud_id,
-  Optional[String] $cloud_auth                                        = $metricbeat::params::cloud_auth,
-  Array[Hash] $modules                                                = $metricbeat::params::modules,
-  Array[String] $module_templates                                     = $metricbeat::params::module_templates,
-  Hash $outputs                                                       = $metricbeat::params::outputs,
-  String $beat_name                                                   = $metricbeat::params::beat_name,
-  String $config_dir                                                  = $metricbeat::params::config_dir,
-  Pattern[/^0[0-7]{3}$/] $config_mode                                 = $metricbeat::params::config_mode,
-  Boolean $disable_configtest                                         = $metricbeat::params::disable_configtest,
-  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $download_url  = $metricbeat::params::download_url,
-  Enum['present', 'absent'] $ensure                                   = $metricbeat::params::ensure,
-  Enum['shell', 'archive'] $extract_method                            = $metricbeat::params::extract_method,
-  Optional[Hash] $fields                                              = $metricbeat::params::fields,
-  Boolean $fields_under_root                                          = $metricbeat::params::fields_under_root,
-  Optional[String] $install_dir                                       = $metricbeat::params::install_dir,
-  Hash $logging                                                       = $metricbeat::params::logging,
-  Enum['5', '6', '7', '8'] $major_version                             = $metricbeat::params::major_version,
-  Boolean $manage_repo                                                = $metricbeat::params::manage_repo,
-  String $package_ensure                                              = $metricbeat::params::package_ensure,
-  Optional[Array[Hash]] $processors                                   = $metricbeat::params::processors,
-  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $proxy_address = $metricbeat::params::proxy_address,
-  Hash $queue                                                         = $metricbeat::params::queue,
-  Integer $queue_size                                                 = $metricbeat::params::queue_size,
-  Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = $metricbeat::params::service_ensure,
-  Boolean $service_has_restart                                        = $metricbeat::params::service_has_restart,
-  Optional[String] $service_provider                                  = $metricbeat::params::service_provider,
-  Optional[Array[String]] $tags                                       = $metricbeat::params::tags,
-  String $tmp_dir                                                     = $metricbeat::params::tmp_dir,
-  Optional[String] $url_arch                                          = $metricbeat::params::url_arch,
-  Optional[Hash] $xpack                                               = $metricbeat::params::xpack,
-  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $yum_repo_url  = $metricbeat::params::yum_repo_url,
-  Hash    $setup                                                      = {},
+  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $apt_repo_url             = $metricbeat::params::apt_repo_url,
+  Optional[String] $cloud_id                                                     = $metricbeat::params::cloud_id,
+  Optional[String] $cloud_auth                                                   = $metricbeat::params::cloud_auth,
+  Array[Hash] $modules                                                           = $metricbeat::params::modules,
+  Array[String] $module_templates                                                = $metricbeat::params::module_templates,
+  Hash $outputs                                                                  = $metricbeat::params::outputs,
+  String $beat_name                                                              = $metricbeat::params::beat_name,
+  String $config_dir                                                             = $metricbeat::params::config_dir,
+  Pattern[/^0[0-7]{3}$/] $config_mode                                            = $metricbeat::params::config_mode,
+  Boolean $disable_configtest                                                    = $metricbeat::params::disable_configtest,
+  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $download_url             = $metricbeat::params::download_url,
+  Enum['present', 'absent'] $ensure                                              = $metricbeat::params::ensure,
+  Enum['shell', 'archive'] $extract_method                                       = $metricbeat::params::extract_method,
+  Optional[Hash] $fields                                                         = $metricbeat::params::fields,
+  Boolean $fields_under_root                                                     = $metricbeat::params::fields_under_root,
+  Optional[String] $install_dir                                                  = $metricbeat::params::install_dir,
+  Hash $logging                                                                  = $metricbeat::params::logging,
+  Enum['5', '6', '7', '8'] $major_version                                        = $metricbeat::params::major_version,
+  Boolean $manage_repo                                                           = $metricbeat::params::manage_repo,
+  String $package_ensure                                                         = $metricbeat::params::package_ensure,
+  Optional[Array[Hash]] $processors                                              = $metricbeat::params::processors,
+  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $proxy_address            = $metricbeat::params::proxy_address,
+  Hash $queue                                                                    = $metricbeat::params::queue,
+  Integer $queue_size                                                            = $metricbeat::params::queue_size,
+  Enum['enabled', 'disabled', 'running', 'unmanaged', 'managed'] $service_ensure = $metricbeat::params::service_ensure,
+  Boolean $service_has_restart                                                   = $metricbeat::params::service_has_restart,
+  Optional[String] $service_provider                                             = $metricbeat::params::service_provider,
+  Optional[Array[String]] $tags                                                  = $metricbeat::params::tags,
+  String $tmp_dir                                                                = $metricbeat::params::tmp_dir,
+  Optional[String] $url_arch                                                     = $metricbeat::params::url_arch,
+  Optional[Hash] $xpack                                                          = $metricbeat::params::xpack,
+  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $yum_repo_url             = $metricbeat::params::yum_repo_url,
+  Hash    $setup                                                                 = {},
 ) inherits metricbeat::params {
 
   $real_download_url = $download_url ? {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,6 +23,10 @@ class metricbeat::service inherits metricbeat {
         $service_ensure = undef
         $service_enable = false
       }
+      'managed': {
+        $service_ensure = undef
+        $service_enable = undef
+      }
       default: {
       }
     }

--- a/spec/classes/metricbeat_spec.rb
+++ b/spec/classes/metricbeat_spec.rb
@@ -390,6 +390,18 @@ describe 'metricbeat' do
             )
           end
         end
+
+        describe 'with service_ensure = managed' do
+          let(:params) { { 'service_ensure' => 'managed' } }
+
+          it do
+            is_expected.to contain_service('metricbeat').with(
+              ensure: nil,
+              enable: nil,
+              hasrestart: true,
+            )
+          end
+        end
       end
 
       context 'with elasticsearch output' do


### PR DESCRIPTION
I needed to have the metricbeat service created by the module while being able to enable or disable it manually.

This need comes from metricbeat deployment recommandations to monitor an elasticsearch cluster with dedicated master nodes. There should be only one instance of metricbeat running (with scope: cluster) : https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-metricbeat.html

This PR adds a managed value for service_ensure parameter which let puppet create the service while leaving its state to the os. 
