### PR TITLE
replace legacy_facts with modern ones

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class metricbeat::params {
   $ensure             = 'present'
   $cloud_id           = undef
   $cloud_auth         = undef
-  $beat_name          = $::hostname
+  $beat_name          = $facts['networking']['hostname']
   $config_mode        = '0600'
   $disable_configtest = false
   $download_url       = undef
@@ -60,7 +60,7 @@ class metricbeat::params {
         'to_syslog' => false,
       }
       $package_ensure   = 'present'
-      $service_provider = $::osfamily ? {
+      $service_provider = $facts['os']['family'] ? {
         'RedHat' => 'redhat',
         default  => undef,
       }
@@ -89,10 +89,10 @@ class metricbeat::params {
       $package_ensure   = '6.6.1'
       $service_provider = undef
       $tmp_dir          = 'C:/Windows/Temp'
-      $url_arch         = $::architecture ? {
+      $url_arch         = $facts['os']['architecture'] ? {
         'x86'   => 'x86',
         'x64'   => 'x86_64',
-        default => fail("${::architecture} is not supported by metricbeat."),
+        default => fail("${facts['os']['architecture']} is not supported by metricbeat."),
       }
     }
     default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -14,7 +14,7 @@ class metricbeat::repo inherits metricbeat {
     default => $metricbeat::yum_repo_url,
   }
 
-  case $facts['osfamily'] {
+  case $facts['os']['family'] {
     'Debian': {
       include ::apt
 


### PR DESCRIPTION
This PR fixes usage on Puppet 8 where legacy-facts are disabled by default.