### PR TITLE
allow puppet-archive 8.x; allow puppet-zypprepo 5.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-pwshlib",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs-powershell",
-      "version_requirement": ">= 1.0.1 < 5.0.0"
+      "version_requirement": ">= 1.0.1 < 7.0.0"
     },
     {
       "name": "puppet-zypprepo",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.0.0 < 8.0.0"
+      "version_requirement": ">= 4.0.0 < 12.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.5.0 < 5.0.0"
+      "version_requirement": ">= 0.5.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-powershell",
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppet-zypprepo",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-pwshlib",

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0 < 7.0.0"
+      "version_requirement": ">= 4.13.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
fixes: `coreyh-metricbeat' (v0.5.0) requires 'puppet-archive' (>= 0.5.0 < 5.0.0)`